### PR TITLE
Issue #6: Firefox Extension Support

### DIFF
--- a/Kinjamprove/manifest.json
+++ b/Kinjamprove/manifest.json
@@ -25,12 +25,12 @@
 			],
 
 			"js": [ "jquery-3.2.1.min.js", "mutation-summary-minified.js", "CommentClass.js", "kinjamprove.js" ],
+			"css": [ "comments.css" ],
 			"run_at": "document_end"
 		}
 	],
 
 	"permissions": [
-		"declarativeContent",
 		"activeTab",
 		"*://*.kinja.com/*",
 		"*://*.avclub.com/*",

--- a/Kinjamprove/manifest.json
+++ b/Kinjamprove/manifest.json
@@ -3,12 +3,12 @@
 	"manifest_version": 2,
 	"description": "View any Kinja comments sections with threaded replies & other improvements at the click of a button. Never click \"Show More\" again!",
 	"version": "0.0.0.32",
-	
-	
-	"icons": { 
-		"128": "icons/kinjamproveLogo.png" 
+
+
+	"icons": {
+		"128": "icons/kinjamproveLogo.png"
 	},
-	
+
 	"content_scripts": [
 		{
 			"matches": [
@@ -23,12 +23,12 @@
 				"*://*.theroot.com/*",
 				"*://*.splinternews.com/*"
 			],
-			
+
 			"js": [ "jquery-3.2.1.min.js", "mutation-summary-minified.js", "CommentClass.js", "kinjamprove.js" ],
 			"run_at": "document_end"
 		}
 	],
-	
+
 	"permissions": [
 		"declarativeContent",
 		"activeTab",
@@ -43,7 +43,7 @@
 		"*://*.theroot.com/*",
 		"*://*.splinternews.com/*"
 	],
-	
+
 	"web_accessible_resources": ["mutation-summary-minified.js", "CommentClass.js", "comments.css"]
 }
 


### PR DESCRIPTION
These simple changes seem to not break Chrome while enabling the extension in Firefox. The manifest.json file format seems to be fairly standardized, so I am not sure why Firefox needs the "css" key and Chrome does not. ¯\_(ツ)_/¯